### PR TITLE
feat/updatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,26 @@ spinner.Stop() // or spinner.Success(), spinner.Error(), spinner.Replace()
 
 ### Updatable Bullets
 
-Create bullets that can be updated after rendering - perfect for showing progress, updating status, and creating dynamic terminal UIs:
+Create bullets that can be updated after rendering - perfect for showing progress, updating status, and creating dynamic terminal UIs.
+
+**⚠️ Important Terminal Requirements:**
+
+The updatable feature requires ANSI escape code support and proper TTY detection. If bullets are not updating in-place (appearing as new lines instead):
+
+1. **Force TTY mode** by setting an environment variable:
+   ```bash
+   export BULLETS_FORCE_TTY=1
+   go run your-program.go
+   ```
+
+2. **Why this is needed:**
+   - `go run` often doesn't properly detect terminal capabilities
+   - Some terminal emulators don't report as TTY correctly
+   - IDE integrated terminals may not support ANSI codes
+
+3. **Fallback behavior:**
+   - When TTY is not detected, updates print as new lines (safe fallback)
+   - This ensures your program works in all environments (logs, CI/CD, etc.)
 
 ```go
 // Create an updatable logger
@@ -274,8 +293,15 @@ go run main.go
 
 **Updatable bullets example:**
 ```bash
+# REQUIRED: Set this environment variable for the updates to work properly
+export BULLETS_FORCE_TTY=1
 go run examples/updatable/main.go
 ```
+
+**Note:** The updatable feature uses ANSI escape codes to update lines in place. You MUST:
+1. Run in a terminal that supports ANSI codes (most modern terminals)
+2. Set `BULLETS_FORCE_TTY=1` environment variable
+3. Run directly in the terminal (not through pipes or output redirection)
 
 This demonstrates all updatable features including status updates, progress tracking, batch operations, and parallel operations.
 

--- a/colors.go
+++ b/colors.go
@@ -5,6 +5,7 @@ import "fmt"
 // ANSI color codes for terminal output
 const (
 	reset = "\033[0m"
+	Reset = reset // Exported version
 
 	// Text colors
 	black   = "\033[30m"
@@ -16,6 +17,16 @@ const (
 	cyan    = "\033[36m"
 	white   = "\033[37m"
 
+	// Exported color constants for public use
+	ColorBlack   = black
+	ColorRed     = red
+	ColorGreen   = green
+	ColorYellow  = yellow
+	ColorBlue    = blue
+	ColorMagenta = magenta
+	ColorCyan    = cyan
+	ColorWhite   = white
+
 	// Bright colors
 	brightBlack   = "\033[90m"
 	brightRed     = "\033[91m"
@@ -26,11 +37,27 @@ const (
 	brightCyan    = "\033[96m"
 	brightWhite   = "\033[97m"
 
+	// Exported bright color constants
+	ColorBrightBlack   = brightBlack
+	ColorBrightRed     = brightRed
+	ColorBrightGreen   = brightGreen
+	ColorBrightYellow  = brightYellow
+	ColorBrightBlue    = brightBlue
+	ColorBrightMagenta = brightMagenta
+	ColorBrightCyan    = brightCyan
+	ColorBrightWhite   = brightWhite
+
 	// Text styles
 	bold      = "\033[1m"
 	dim       = "\033[2m"
 	italic    = "\033[3m"
 	underline = "\033[4m"
+
+	// Exported style constants
+	StyleBold      = bold
+	StyleDim       = dim
+	StyleItalic    = italic
+	StyleUnderline = underline
 )
 
 // Bullet symbols
@@ -42,9 +69,14 @@ const (
 	bulletDebug   = "○"
 )
 
-// colorize wraps text in ANSI color codes
+// colorize wraps text in ANSI color codes (internal use)
 func colorize(color, text string) string {
 	return color + text + reset
+}
+
+// Colorize wraps text in ANSI color codes (exported for public use)
+func Colorize(color, text string) string {
+	return colorize(color, text)
 }
 
 // getBulletStyle returns the colored bullet and color for a given level

--- a/colors_test.go
+++ b/colors_test.go
@@ -1,0 +1,118 @@
+package bullets
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestColorize(t *testing.T) {
+	result := colorize(red, "error")
+
+	if !strings.Contains(result, "error") {
+		t.Errorf("Expected colorize to contain 'error', got %q", result)
+	}
+
+	if !strings.HasPrefix(result, red) {
+		t.Errorf("Expected result to start with red color code")
+	}
+
+	if !strings.HasSuffix(result, reset) {
+		t.Errorf("Expected result to end with reset code")
+	}
+}
+
+func TestGetBulletStyleDefault(t *testing.T) {
+	customBullets := make(map[Level]string)
+
+	tests := []struct {
+		level              Level
+		useSpecialBullets  bool
+		expectedBullet     string
+	}{
+		{InfoLevel, false, bulletInfo},
+		{WarnLevel, false, bulletInfo},
+		{ErrorLevel, false, bulletInfo},
+		{DebugLevel, false, bulletInfo}, // Debug uses bulletInfo when special bullets disabled
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level.String(), func(t *testing.T) {
+			bullet, _ := getBulletStyle(tt.level, tt.useSpecialBullets, customBullets)
+
+			if !strings.Contains(bullet, tt.expectedBullet) {
+				t.Errorf("Expected bullet to contain %q, got %q", tt.expectedBullet, bullet)
+			}
+		})
+	}
+}
+
+func TestGetBulletStyleSpecial(t *testing.T) {
+	customBullets := make(map[Level]string)
+
+	tests := []struct {
+		level            Level
+		expectedContains string
+	}{
+		{InfoLevel, bulletInfo},
+		{WarnLevel, bulletWarn},
+		{ErrorLevel, bulletError},
+		{DebugLevel, bulletDebug},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.level.String()+"_special", func(t *testing.T) {
+			bullet, _ := getBulletStyle(tt.level, true, customBullets)
+
+			if !strings.Contains(bullet, tt.expectedContains) {
+				t.Errorf("Expected special bullet to contain %q, got %q", tt.expectedContains, bullet)
+			}
+		})
+	}
+}
+
+func TestGetBulletStyleCustom(t *testing.T) {
+	customBullets := map[Level]string{
+		InfoLevel:  "→",
+		ErrorLevel: "✖",
+	}
+
+	bullet, _ := getBulletStyle(InfoLevel, false, customBullets)
+	if !strings.Contains(bullet, "→") {
+		t.Errorf("Expected custom bullet '→', got %q", bullet)
+	}
+
+	bullet, _ = getBulletStyle(ErrorLevel, true, customBullets)
+	if !strings.Contains(bullet, "✖") {
+		t.Errorf("Expected custom bullet '✖' (should override special), got %q", bullet)
+	}
+}
+
+func TestFormatMessage(t *testing.T) {
+	customBullets := make(map[Level]string)
+
+	result := formatMessage(InfoLevel, "test message", false, customBullets)
+
+	if !strings.Contains(result, "test message") {
+		t.Errorf("Expected formatted message to contain 'test message', got %q", result)
+	}
+
+	if !strings.Contains(result, bulletInfo) {
+		t.Errorf("Expected formatted message to contain bullet, got %q", result)
+	}
+}
+
+func TestFormatMessageWithCustomBullet(t *testing.T) {
+	customBullets := map[Level]string{
+		WarnLevel: "⚡",
+	}
+
+	result := formatMessage(WarnLevel, "warning", false, customBullets)
+
+	if !strings.Contains(result, "⚡") {
+		t.Errorf("Expected formatted message to contain custom bullet '⚡', got %q", result)
+	}
+
+	if !strings.Contains(result, "warning") {
+		t.Errorf("Expected formatted message to contain 'warning', got %q", result)
+	}
+}

--- a/examples/basic/go.mod
+++ b/examples/basic/go.mod
@@ -1,7 +1,0 @@
-module example
-
-go 1.21
-
-replace github.com/sgaunet/bullets => ../..
-
-require github.com/sgaunet/bullets v0.0.0-00010101000000-000000000000

--- a/examples/updatable/main.go
+++ b/examples/updatable/main.go
@@ -10,6 +10,12 @@ import (
 )
 
 func main() {
+	// IMPORTANT: If updates are not working in-place (just printing new lines),
+	// set the environment variable BULLETS_FORCE_TTY=1 before running this example.
+	// This is often needed when running via 'go run' or in certain terminals.
+	//
+	// Example: export BULLETS_FORCE_TTY=1 && go run main.go
+
 	// Create an updatable logger
 	logger := bullets.NewUpdatable(os.Stdout)
 
@@ -47,15 +53,19 @@ func main() {
 
 	var wg sync.WaitGroup
 	// Simulate different download speeds
-	wg.Go(func() {
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
 		updateDownload(download1, "package-1.tar.gz", 50*time.Millisecond)
-	})
-	wg.Go(func() {
+	}()
+	go func() {
+		defer wg.Done()
 		updateDownload(download2, "package-2.tar.gz", 100*time.Millisecond)
-	})
-	wg.Go(func() {
+	}()
+	go func() {
+		defer wg.Done()
 		updateDownload(download3, "package-3.tar.gz", 75*time.Millisecond)
-	})
+	}()
 
 	wg.Wait()
 	time.Sleep(500 * time.Millisecond)
@@ -212,8 +222,9 @@ func main() {
 
 // updateDownload simulates a download with progress updates
 func updateDownload(handle *bullets.BulletHandle, filename string, speed time.Duration) {
+	// Progress updates will be shown with the original message
 	for i := 0; i <= 100; i += 10 {
-		handle.Progress(i, 100).UpdateMessage(filename)
+		handle.Progress(i, 100)
 		time.Sleep(speed)
 	}
 	handle.Success(filename + " downloaded successfully ✓")

--- a/examples/updatable/main.go
+++ b/examples/updatable/main.go
@@ -1,0 +1,220 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/sgaunet/bullets"
+)
+
+func main() {
+	// Create an updatable logger
+	logger := bullets.NewUpdatable(os.Stdout)
+
+	logger.Info("Starting updatable bullets demonstration")
+	logger.IncreasePadding()
+
+	// Example 1: Simple status updates
+	logger.Info("Example 1: Simple status updates")
+	logger.IncreasePadding()
+
+	task1 := logger.InfoHandle("Task 1: Initializing...")
+	task2 := logger.InfoHandle("Task 2: Waiting...")
+	task3 := logger.InfoHandle("Task 3: Pending...")
+
+	time.Sleep(1 * time.Second)
+	task1.Success("Task 1: Completed ✓")
+
+	time.Sleep(1 * time.Second)
+	task2.UpdateLevel(bullets.WarnLevel).UpdateMessage("Task 2: Warning - retrying...")
+
+	time.Sleep(1 * time.Second)
+	task2.Success("Task 2: Completed after retry ✓")
+	task3.Error("Task 3: Failed ✗")
+
+	logger.DecreasePadding()
+	fmt.Println()
+
+	// Example 2: Progress tracking
+	logger.Info("Example 2: Download progress tracking")
+	logger.IncreasePadding()
+
+	download1 := logger.InfoHandle("Downloading package-1.tar.gz...")
+	download2 := logger.InfoHandle("Downloading package-2.tar.gz...")
+	download3 := logger.InfoHandle("Downloading package-3.tar.gz...")
+
+	var wg sync.WaitGroup
+	// Simulate different download speeds
+	wg.Go(func() {
+		updateDownload(download1, "package-1.tar.gz", 50*time.Millisecond)
+	})
+	wg.Go(func() {
+		updateDownload(download2, "package-2.tar.gz", 100*time.Millisecond)
+	})
+	wg.Go(func() {
+		updateDownload(download3, "package-3.tar.gz", 75*time.Millisecond)
+	})
+
+	wg.Wait()
+	time.Sleep(500 * time.Millisecond)
+	logger.DecreasePadding()
+	fmt.Println()
+
+	// Example 3: Batch operations
+	logger.Info("Example 3: Batch test execution")
+	logger.IncreasePadding()
+
+	tests := []*bullets.BulletHandle{
+		logger.InfoHandle("Running test: auth_test.go"),
+		logger.InfoHandle("Running test: api_test.go"),
+		logger.InfoHandle("Running test: db_test.go"),
+		logger.InfoHandle("Running test: cache_test.go"),
+		logger.InfoHandle("Running test: integration_test.go"),
+	}
+
+	// Create a handle group (not used in this example, but available for batch operations)
+	// testGroup := bullets.NewHandleGroup(tests...)
+
+	time.Sleep(2 * time.Second)
+
+	// Update individual tests
+	tests[0].Success("Test passed: auth_test.go ✓")
+	tests[1].Success("Test passed: api_test.go ✓")
+	tests[2].Error("Test failed: db_test.go ✗")
+	tests[3].Success("Test passed: cache_test.go ✓")
+	tests[4].Warning("Test skipped: integration_test.go ⚠")
+
+	logger.DecreasePadding()
+	fmt.Println()
+
+	// Example 4: Build pipeline simulation
+	logger.Info("Example 4: CI/CD Pipeline")
+	logger.IncreasePadding()
+
+	pipeline := []struct {
+		name   string
+		handle *bullets.BulletHandle
+		delay  time.Duration
+		status string
+	}{
+		{"Checkout code", nil, 500 * time.Millisecond, "success"},
+		{"Install dependencies", nil, 1 * time.Second, "success"},
+		{"Run linter", nil, 800 * time.Millisecond, "warning"},
+		{"Run tests", nil, 2 * time.Second, "success"},
+		{"Build application", nil, 1500 * time.Millisecond, "success"},
+		{"Deploy to staging", nil, 1 * time.Second, "error"},
+	}
+
+	// Start all pipeline steps as pending
+	for i := range pipeline {
+		pipeline[i].handle = logger.InfoHandle(pipeline[i].name + " ⏳")
+	}
+
+	// Execute pipeline steps
+	for i, step := range pipeline {
+		time.Sleep(step.delay)
+
+		switch step.status {
+		case "success":
+			step.handle.Success(step.name + " ✓")
+		case "warning":
+			step.handle.Warning(step.name + " ⚠ (with warnings)")
+		case "error":
+			step.handle.Error(step.name + " ✗ (failed)")
+			// Stop pipeline on error
+			for j := i + 1; j < len(pipeline); j++ {
+				pipeline[j].handle.UpdateColor(bullets.ColorBrightBlack).
+					UpdateMessage(pipeline[j].name + " (skipped)")
+			}
+			break
+		}
+
+		if step.status == "error" {
+			break
+		}
+	}
+
+	logger.DecreasePadding()
+	fmt.Println()
+
+	// Example 5: Parallel operations with different outcomes
+	logger.Info("Example 5: Parallel service health checks")
+	logger.IncreasePadding()
+
+	services := map[string]*bullets.BulletHandle{
+		"Database":      logger.InfoHandle("Checking database..."),
+		"Redis":         logger.InfoHandle("Checking Redis..."),
+		"API Gateway":   logger.InfoHandle("Checking API Gateway..."),
+		"Auth Service":  logger.InfoHandle("Checking Auth Service..."),
+		"Message Queue": logger.InfoHandle("Checking Message Queue..."),
+	}
+
+	// Simulate health checks
+	go func() {
+		time.Sleep(500 * time.Millisecond)
+		services["Database"].Success("Database: Healthy (15ms)")
+	}()
+
+	go func() {
+		time.Sleep(700 * time.Millisecond)
+		services["Redis"].Success("Redis: Healthy (8ms)")
+	}()
+
+	go func() {
+		time.Sleep(1200 * time.Millisecond)
+		services["API Gateway"].Warning("API Gateway: Degraded (high latency)")
+	}()
+
+	go func() {
+		time.Sleep(900 * time.Millisecond)
+		services["Auth Service"].Success("Auth Service: Healthy (22ms)")
+	}()
+
+	go func() {
+		time.Sleep(1500 * time.Millisecond)
+		services["Message Queue"].Error("Message Queue: Unreachable")
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	logger.DecreasePadding()
+	fmt.Println()
+
+	// Example 6: Using HandleChain for coordinated updates
+	logger.Info("Example 6: Deployment across regions")
+	logger.IncreasePadding()
+
+	usEast := logger.InfoHandle("Deploying to US-East...")
+	usWest := logger.InfoHandle("Deploying to US-West...")
+	euWest := logger.InfoHandle("Deploying to EU-West...")
+	apSouth := logger.InfoHandle("Deploying to AP-South...")
+
+	// Create a chain for all regions
+	regions := bullets.Chain(usEast, usWest, euWest, apSouth)
+
+	time.Sleep(1 * time.Second)
+	regions.WithField("version", "v2.1.0")
+
+	time.Sleep(1 * time.Second)
+	usEast.Success("US-East: Deployed successfully")
+	usWest.Success("US-West: Deployed successfully")
+
+	time.Sleep(500 * time.Millisecond)
+	euWest.Success("EU-West: Deployed successfully")
+	apSouth.Success("AP-South: Deployed successfully")
+
+	logger.DecreasePadding()
+
+	logger.Success("All examples completed!")
+}
+
+// updateDownload simulates a download with progress updates
+func updateDownload(handle *bullets.BulletHandle, filename string, speed time.Duration) {
+	for i := 0; i <= 100; i += 10 {
+		handle.Progress(i, 100).UpdateMessage(filename)
+		time.Sleep(speed)
+	}
+	handle.Success(filename + " downloaded successfully ✓")
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sgaunet/bullets
 
-go 1.24.0
+go 1.25.0
 
 require golang.org/x/term v0.35.0
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,7 @@
 module github.com/sgaunet/bullets
 
-go 1.21
+go 1.24.0
+
+require golang.org/x/term v0.35.0
+
+require golang.org/x/sys v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/term v0.35.0 h1:bZBVKBudEyhRcajGcNc3jIfWPqV4y/Kt2XcoigOWtDQ=
+golang.org/x/term v0.35.0/go.mod h1:TPGtkTLesOwf2DE8CgVYiZinHAOuy5AYUYT1lENIZnA=

--- a/handle.go
+++ b/handle.go
@@ -1,0 +1,288 @@
+package bullets
+
+import (
+	"fmt"
+	"sync"
+	"time"
+)
+
+// HandleState represents the state of a bullet handle
+type HandleState struct {
+	Level   Level
+	Message string
+	Color   string
+	Bullet  string
+	Fields  map[string]interface{}
+}
+
+// GetState returns the current state of the handle
+func (h *BulletHandle) GetState() HandleState {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	fields := make(map[string]interface{})
+	for k, v := range h.fields {
+		fields[k] = v
+	}
+
+	return HandleState{
+		Level:   h.level,
+		Message: h.message,
+		Color:   h.color,
+		Bullet:  h.bullet,
+		Fields:  fields,
+	}
+}
+
+// SetState sets the complete state of the handle
+func (h *BulletHandle) SetState(state HandleState) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.level = state.Level
+	h.message = state.Message
+	if state.Color != "" {
+		h.color = state.Color
+	}
+	if state.Bullet != "" {
+		h.bullet = state.Bullet
+	}
+
+	// Update fields
+	h.fields = make(map[string]interface{})
+	for k, v := range state.Fields {
+		h.fields[k] = v
+	}
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// UpdateColor updates just the color of the bullet
+func (h *BulletHandle) UpdateColor(color string) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.color = color
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// UpdateBullet updates just the bullet symbol
+func (h *BulletHandle) UpdateBullet(bullet string) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.bullet = bullet
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// Pulse creates a pulsing effect by alternating between two states
+func (h *BulletHandle) Pulse(duration time.Duration, alternateMsg string) {
+	if h.lineNum == -1 || !h.logger.isTTY {
+		return
+	}
+
+	originalMsg := h.message
+
+	go func() {
+		ticker := time.NewTicker(500 * time.Millisecond)
+		timer := time.NewTimer(duration)
+		defer ticker.Stop()
+		defer timer.Stop()
+
+		toggle := false
+		for {
+			select {
+			case <-timer.C:
+				h.UpdateMessage(originalMsg)
+				return
+			case <-ticker.C:
+				if toggle {
+					h.UpdateMessage(originalMsg)
+				} else {
+					h.UpdateMessage(alternateMsg)
+				}
+				toggle = !toggle
+			}
+		}
+	}()
+}
+
+// Progress updates the bullet to show progress
+func (h *BulletHandle) Progress(current, total int) *BulletHandle {
+	percentage := (current * 100) / total
+	progressBar := renderProgressBar(percentage)
+
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	// Update message with progress
+	h.message = h.message + " " + progressBar
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// renderProgressBar creates a simple ASCII progress bar
+func renderProgressBar(percentage int) string {
+	barWidth := 20
+	filled := (percentage * barWidth) / 100
+
+	bar := "["
+	for i := 0; i < barWidth; i++ {
+		if i < filled {
+			bar += "="
+		} else if i == filled {
+			bar += ">"
+		} else {
+			bar += " "
+		}
+	}
+	bar += "]"
+
+	return bar + " " + colorize(cyan, fmt.Sprintf("%d%%", percentage))
+}
+
+// HandleGroup manages a group of related handles
+type HandleGroup struct {
+	handles []*BulletHandle
+	mu      sync.RWMutex
+}
+
+// NewHandleGroup creates a new handle group
+func NewHandleGroup(handles ...*BulletHandle) *HandleGroup {
+	return &HandleGroup{
+		handles: handles,
+	}
+}
+
+// Add adds a handle to the group
+func (hg *HandleGroup) Add(handle *BulletHandle) {
+	hg.mu.Lock()
+	defer hg.mu.Unlock()
+	hg.handles = append(hg.handles, handle)
+}
+
+// UpdateAll updates all handles in the group
+func (hg *HandleGroup) UpdateAll(level Level, msg string) {
+	hg.mu.RLock()
+	defer hg.mu.RUnlock()
+
+	for _, h := range hg.handles {
+		h.Update(level, msg)
+	}
+}
+
+// SuccessAll marks all handles as success
+func (hg *HandleGroup) SuccessAll(msg string) {
+	hg.mu.RLock()
+	defer hg.mu.RUnlock()
+
+	for _, h := range hg.handles {
+		h.Success(msg)
+	}
+}
+
+// ErrorAll marks all handles as error
+func (hg *HandleGroup) ErrorAll(msg string) {
+	hg.mu.RLock()
+	defer hg.mu.RUnlock()
+
+	for _, h := range hg.handles {
+		h.Error(msg)
+	}
+}
+
+// UpdateEach updates each handle with a different message
+func (hg *HandleGroup) UpdateEach(updates map[int]struct {
+	Level   Level
+	Message string
+}) {
+	hg.mu.RLock()
+	defer hg.mu.RUnlock()
+
+	for idx, update := range updates {
+		if idx < len(hg.handles) {
+			hg.handles[idx].Update(update.Level, update.Message)
+		}
+	}
+}
+
+// Clear removes all handles from the group
+func (hg *HandleGroup) Clear() {
+	hg.mu.Lock()
+	defer hg.mu.Unlock()
+	hg.handles = nil
+}
+
+// Size returns the number of handles in the group
+func (hg *HandleGroup) Size() int {
+	hg.mu.RLock()
+	defer hg.mu.RUnlock()
+	return len(hg.handles)
+}
+
+// Get returns the handle at the specified index
+func (hg *HandleGroup) Get(index int) *BulletHandle {
+	hg.mu.RLock()
+	defer hg.mu.RUnlock()
+
+	if index >= 0 && index < len(hg.handles) {
+		return hg.handles[index]
+	}
+	return nil
+}
+
+// HandleChain allows chaining updates to multiple handles
+type HandleChain struct {
+	handles []*BulletHandle
+}
+
+// Chain creates a new handle chain
+func Chain(handles ...*BulletHandle) *HandleChain {
+	return &HandleChain{handles: handles}
+}
+
+// Update updates all handles in the chain
+func (hc *HandleChain) Update(level Level, msg string) *HandleChain {
+	for _, h := range hc.handles {
+		h.Update(level, msg)
+	}
+	return hc
+}
+
+// Success marks all handles in the chain as success
+func (hc *HandleChain) Success(msg string) *HandleChain {
+	for _, h := range hc.handles {
+		h.Success(msg)
+	}
+	return hc
+}
+
+// Error marks all handles in the chain as error
+func (hc *HandleChain) Error(msg string) *HandleChain {
+	for _, h := range hc.handles {
+		h.Error(msg)
+	}
+	return hc
+}
+
+// WithField adds a field to all handles in the chain
+func (hc *HandleChain) WithField(key string, value interface{}) *HandleChain {
+	for _, h := range hc.handles {
+		h.WithField(key, value)
+	}
+	return hc
+}

--- a/handle.go
+++ b/handle.go
@@ -126,8 +126,8 @@ func (h *BulletHandle) Progress(current, total int) *BulletHandle {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	// Update message with progress
-	h.message = h.message + " " + progressBar
+	// Store progress bar separately, keep message intact
+	h.progressBar = progressBar
 
 	if h.lineNum != -1 && h.logger.isTTY {
 		h.redraw()
@@ -144,7 +144,7 @@ func renderProgressBar(percentage int) string {
 	for i := 0; i < barWidth; i++ {
 		if i < filled {
 			bar += "="
-		} else if i == filled {
+		} else if i == filled && percentage < 100 {
 			bar += ">"
 		} else {
 			bar += " "
@@ -152,7 +152,7 @@ func renderProgressBar(percentage int) string {
 	}
 	bar += "]"
 
-	return bar + " " + colorize(cyan, fmt.Sprintf("%d%%", percentage))
+	return fmt.Sprintf("%s %d%%", bar, percentage)
 }
 
 // HandleGroup manages a group of related handles

--- a/handle_test.go
+++ b/handle_test.go
@@ -1,0 +1,135 @@
+package bullets
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestHandleGroup_SuccessAll(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	h1 := logger.InfoHandle("Task 1")
+	h2 := logger.InfoHandle("Task 2")
+	h3 := logger.InfoHandle("Task 3")
+
+	group := NewHandleGroup(h1, h2, h3)
+	group.SuccessAll("All completed")
+
+	for i := 0; i < group.Size(); i++ {
+		h := group.Get(i)
+		state := h.GetState()
+		if state.Message != "All completed" {
+			t.Errorf("Handle %d: expected 'All completed', got %s", i, state.Message)
+		}
+	}
+}
+
+func TestHandleGroup_ErrorAll(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	h1 := logger.InfoHandle("Service 1")
+	h2 := logger.InfoHandle("Service 2")
+	h3 := logger.InfoHandle("Service 3")
+
+	group := NewHandleGroup(h1, h2, h3)
+	group.ErrorAll("Connection failed")
+
+	for i := 0; i < group.Size(); i++ {
+		h := group.Get(i)
+		state := h.GetState()
+		if state.Level != ErrorLevel {
+			t.Errorf("Handle %d: expected ErrorLevel, got %v", i, state.Level)
+		}
+		if state.Message != "Connection failed" {
+			t.Errorf("Handle %d: expected 'Connection failed', got %s", i, state.Message)
+		}
+	}
+}
+
+func TestHandleChain_Error(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	h1 := logger.InfoHandle("Process 1")
+	h2 := logger.InfoHandle("Process 2")
+
+	chain := Chain(h1, h2)
+	chain.Error("Critical error occurred")
+
+	handles := []*BulletHandle{h1, h2}
+	for i, h := range handles {
+		state := h.GetState()
+		if state.Level != ErrorLevel {
+			t.Errorf("Handle %d: expected ErrorLevel, got %v", i, state.Level)
+		}
+		if state.Message != "Critical error occurred" {
+			t.Errorf("Handle %d: expected error message, got %s", i, state.Message)
+		}
+	}
+}
+
+func TestRenderProgressBar(t *testing.T) {
+	tests := []struct {
+		percentage int
+		expected   string // partial match
+	}{
+		{0, "[>                   ] "},
+		{25, "[====>               ] "},
+		{50, "[==========>         ] "},
+		{75, "[===============>    ] "},
+		{100, "[====================] "},
+	}
+
+	for _, tt := range tests {
+		result := renderProgressBar(tt.percentage)
+
+		// Check for percentage in result
+		expectedPercentage := fmt.Sprintf("%d%%", tt.percentage)
+		if !strings.Contains(result, expectedPercentage) {
+			t.Errorf("Progress bar for %d%% doesn't contain percentage: %s", tt.percentage, result)
+		}
+
+		// Check bar structure
+		if !strings.HasPrefix(result, "[") {
+			t.Errorf("Progress bar for %d%% doesn't start with '[': %s", tt.percentage, result)
+		}
+	}
+}
+
+func TestHandleGroup_GetBounds(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	group := NewHandleGroup()
+
+	// Test getting from empty group
+	if group.Get(0) != nil {
+		t.Error("Get(0) on empty group should return nil")
+	}
+
+	// Add handles
+	h1 := logger.InfoHandle("Test 1")
+	h2 := logger.InfoHandle("Test 2")
+	group.Add(h1)
+	group.Add(h2)
+
+	// Test valid indices
+	if group.Get(0) != h1 {
+		t.Error("Get(0) should return first handle")
+	}
+	if group.Get(1) != h2 {
+		t.Error("Get(1) should return second handle")
+	}
+
+	// Test out of bounds
+	if group.Get(-1) != nil {
+		t.Error("Get(-1) should return nil")
+	}
+	if group.Get(2) != nil {
+		t.Error("Get(2) should return nil when size is 2")
+	}
+}

--- a/spinner_test.go
+++ b/spinner_test.go
@@ -1,0 +1,215 @@
+package bullets
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestSpinnerCreation(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.Spinner("loading")
+
+	if spinner == nil {
+		t.Fatal("Spinner() returned nil")
+	}
+
+	if spinner.msg != "loading" {
+		t.Errorf("Expected spinner message 'loading', got %q", spinner.msg)
+	}
+
+	spinner.Stop()
+}
+
+func TestSpinnerStop(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.Spinner("processing")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Stop()
+
+	if !spinner.stopped {
+		t.Error("Expected spinner to be stopped")
+	}
+}
+
+func TestSpinnerSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.Spinner("downloading")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Success("download complete")
+
+	output := buf.String()
+	if !strings.Contains(output, "download complete") {
+		t.Errorf("Expected output to contain 'download complete', got %q", output)
+	}
+}
+
+func TestSpinnerError(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.Spinner("connecting")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Error("connection failed")
+
+	output := buf.String()
+	if !strings.Contains(output, "connection failed") {
+		t.Errorf("Expected output to contain 'connection failed', got %q", output)
+	}
+}
+
+func TestSpinnerFail(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.Spinner("uploading")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Fail("upload failed")
+
+	output := buf.String()
+	if !strings.Contains(output, "upload failed") {
+		t.Errorf("Expected output to contain 'upload failed', got %q", output)
+	}
+}
+
+func TestSpinnerReplace(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.Spinner("processing")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Replace("processed 100 items")
+
+	output := buf.String()
+	if !strings.Contains(output, "processed 100 items") {
+		t.Errorf("Expected output to contain 'processed 100 items', got %q", output)
+	}
+}
+
+func TestSpinnerDots(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.SpinnerDots("loading")
+
+	if len(spinner.frames) == 0 {
+		t.Error("Expected spinner to have frames")
+	}
+
+	spinner.Stop()
+}
+
+func TestSpinnerCircle(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.SpinnerCircle("processing")
+
+	expectedFrames := []string{"◐", "◓", "◑", "◒"}
+	if len(spinner.frames) != len(expectedFrames) {
+		t.Errorf("Expected %d frames, got %d", len(expectedFrames), len(spinner.frames))
+	}
+
+	spinner.Stop()
+}
+
+func TestSpinnerBounce(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.SpinnerBounce("bouncing")
+
+	if len(spinner.frames) == 0 {
+		t.Error("Expected spinner to have frames")
+	}
+
+	spinner.Stop()
+}
+
+func TestSpinnerWithFrames(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	customFrames := []string{"1", "2", "3", "4"}
+	spinner := logger.SpinnerWithFrames("custom", customFrames)
+
+	if len(spinner.frames) != 4 {
+		t.Errorf("Expected 4 frames, got %d", len(spinner.frames))
+	}
+
+	for i, frame := range customFrames {
+		if spinner.frames[i] != frame {
+			t.Errorf("Expected frame %d to be %q, got %q", i, frame, spinner.frames[i])
+		}
+	}
+
+	spinner.Stop()
+}
+
+func TestSpinnerWithPadding(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.IncreasePadding()
+	logger.IncreasePadding()
+
+	spinner := logger.Spinner("indented")
+
+	if spinner.padding != 2 {
+		t.Errorf("Expected spinner padding to be 2, got %d", spinner.padding)
+	}
+
+	spinner.Stop()
+}
+
+func TestSpinnerMultipleStops(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	spinner := logger.Spinner("test")
+	time.Sleep(50 * time.Millisecond)
+
+	spinner.Stop()
+	spinner.Stop() // Should not panic
+
+	if !spinner.stopped {
+		t.Error("Expected spinner to be stopped")
+	}
+}
+
+func TestSpinnerWithSpecialBullets(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.SetUseSpecialBullets(true)
+
+	spinner := logger.Spinner("loading")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Success("done")
+
+	output := buf.String()
+	// Should use special success bullet
+	if !strings.Contains(output, "✓") && !strings.Contains(output, "done") {
+		t.Errorf("Expected special bullet or 'done' in output, got %q", output)
+	}
+}
+
+func TestSpinnerWithCustomBullet(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+	logger.SetBullet(InfoLevel, "★")
+
+	spinner := logger.Spinner("loading")
+	time.Sleep(100 * time.Millisecond)
+	spinner.Replace("finished")
+
+	output := buf.String()
+	if !strings.Contains(output, "★") {
+		t.Errorf("Expected custom bullet '★' in output, got %q", output)
+	}
+}

--- a/updatable.go
+++ b/updatable.go
@@ -1,0 +1,363 @@
+package bullets
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"golang.org/x/term"
+)
+
+// UpdatableLogger wraps a regular Logger and provides updatable bullet functionality
+type UpdatableLogger struct {
+	*Logger
+	mu       sync.RWMutex
+	handles  []*BulletHandle
+	lineCount int  // Track total lines written
+	isTTY    bool  // Whether output is a terminal
+}
+
+// BulletHandle represents a handle to an updatable bullet
+type BulletHandle struct {
+	logger    *UpdatableLogger
+	lineNum   int     // Line number relative to start
+	level     Level
+	message   string
+	color     string
+	bullet    string
+	padding   int
+	fields    map[string]interface{}
+	mu        sync.Mutex
+}
+
+// ANSI escape codes for cursor control
+const (
+	ansiSaveCursor    = "\033[s"
+	ansiRestoreCursor = "\033[u"
+	ansiClearLine     = "\033[2K"
+	ansiMoveUp        = "\033[%dA"
+	ansiMoveDown      = "\033[%dB"
+	ansiMoveToCol     = "\033[0G"
+)
+
+// NewUpdatable creates a new updatable logger
+func NewUpdatable(w io.Writer) *UpdatableLogger {
+	// Check if output is a terminal
+	isTTY := false
+	if f, ok := w.(*os.File); ok {
+		isTTY = term.IsTerminal(int(f.Fd()))
+	}
+
+	return &UpdatableLogger{
+		Logger:  New(w),
+		handles: make([]*BulletHandle, 0),
+		isTTY:   isTTY,
+	}
+}
+
+// InfoHandle logs an info message and returns a handle for updates
+func (ul *UpdatableLogger) InfoHandle(msg string) *BulletHandle {
+	return ul.logHandle(InfoLevel, msg)
+}
+
+// DebugHandle logs a debug message and returns a handle for updates
+func (ul *UpdatableLogger) DebugHandle(msg string) *BulletHandle {
+	return ul.logHandle(DebugLevel, msg)
+}
+
+// WarnHandle logs a warning message and returns a handle for updates
+func (ul *UpdatableLogger) WarnHandle(msg string) *BulletHandle {
+	return ul.logHandle(WarnLevel, msg)
+}
+
+// ErrorHandle logs an error message and returns a handle for updates
+func (ul *UpdatableLogger) ErrorHandle(msg string) *BulletHandle {
+	return ul.logHandle(ErrorLevel, msg)
+}
+
+// logHandle creates a bullet and returns a handle to it
+func (ul *UpdatableLogger) logHandle(level Level, msg string) *BulletHandle {
+	ul.mu.Lock()
+	defer ul.mu.Unlock()
+
+	// Log the message normally
+	ul.Logger.log(level, msg)
+
+	// If not a TTY, return a dummy handle
+	if !ul.isTTY {
+		return &BulletHandle{
+			logger:  ul,
+			lineNum: -1,
+			level:   level,
+			message: msg,
+		}
+	}
+
+	// Create and register handle
+	handle := &BulletHandle{
+		logger:  ul,
+		lineNum: ul.lineCount,
+		level:   level,
+		message: msg,
+		padding: ul.Logger.padding,
+		fields:  make(map[string]interface{}),
+	}
+
+	// Copy fields from logger
+	ul.Logger.mu.Lock()
+	for k, v := range ul.Logger.fields {
+		handle.fields[k] = v
+	}
+	ul.Logger.mu.Unlock()
+
+	ul.handles = append(ul.handles, handle)
+	ul.lineCount++
+
+	return handle
+}
+
+// Update updates the bullet with a new message and level
+func (h *BulletHandle) Update(level Level, msg string) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.level = level
+	h.message = msg
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// UpdateMessage updates just the message text
+func (h *BulletHandle) UpdateMessage(msg string) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.message = msg
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// UpdateLevel updates just the level (and thus color/bullet)
+func (h *BulletHandle) UpdateLevel(level Level) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.level = level
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// Success updates the bullet to show success
+func (h *BulletHandle) Success(msg string) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	h.message = msg
+
+	if h.lineNum != -1 && h.logger.isTTY {
+		// Success uses a special rendering
+		h.redrawSuccess()
+	}
+	return h
+}
+
+// Error updates the bullet to show an error
+func (h *BulletHandle) Error(msg string) *BulletHandle {
+	return h.Update(ErrorLevel, msg)
+}
+
+// Warning updates the bullet to show a warning
+func (h *BulletHandle) Warning(msg string) *BulletHandle {
+	return h.Update(WarnLevel, msg)
+}
+
+// WithField adds a field to this bullet
+func (h *BulletHandle) WithField(key string, value interface{}) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.fields == nil {
+		h.fields = make(map[string]interface{})
+	}
+	h.fields[key] = value
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// WithFields adds multiple fields to this bullet
+func (h *BulletHandle) WithFields(fields map[string]interface{}) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	for k, v := range fields {
+		h.fields[k] = v
+	}
+	if h.lineNum != -1 && h.logger.isTTY {
+		h.redraw()
+	}
+	return h
+}
+
+// redraw redraws the bullet at its original position
+func (h *BulletHandle) redraw() {
+	h.logger.mu.RLock()
+	currentLine := h.logger.lineCount
+	h.logger.mu.RUnlock()
+
+	linesToMoveUp := currentLine - h.lineNum
+
+	if linesToMoveUp > 0 {
+		// Save cursor, move up, redraw, restore cursor
+		fmt.Fprint(h.logger.writer, ansiSaveCursor)
+		fmt.Fprintf(h.logger.writer, ansiMoveUp, linesToMoveUp)
+		fmt.Fprint(h.logger.writer, ansiClearLine)
+		fmt.Fprint(h.logger.writer, ansiMoveToCol)
+
+		// Render the updated bullet
+		h.render()
+
+		fmt.Fprint(h.logger.writer, ansiRestoreCursor)
+	} else {
+		// Current line, just clear and redraw
+		fmt.Fprint(h.logger.writer, "\r")
+		fmt.Fprint(h.logger.writer, ansiClearLine)
+		h.render()
+	}
+}
+
+// redrawSuccess redraws the bullet as a success message
+func (h *BulletHandle) redrawSuccess() {
+	h.logger.mu.RLock()
+	currentLine := h.logger.lineCount
+	h.logger.mu.RUnlock()
+
+	linesToMoveUp := currentLine - h.lineNum
+
+	if linesToMoveUp > 0 {
+		fmt.Fprint(h.logger.writer, ansiSaveCursor)
+		fmt.Fprintf(h.logger.writer, ansiMoveUp, linesToMoveUp)
+		fmt.Fprint(h.logger.writer, ansiClearLine)
+		fmt.Fprint(h.logger.writer, ansiMoveToCol)
+
+		// Render as success
+		h.renderSuccess()
+
+		fmt.Fprint(h.logger.writer, ansiRestoreCursor)
+	} else {
+		fmt.Fprint(h.logger.writer, "\r")
+		fmt.Fprint(h.logger.writer, ansiClearLine)
+		h.renderSuccess()
+	}
+}
+
+// render outputs the bullet without cursor manipulation
+func (h *BulletHandle) render() {
+	indent := strings.Repeat("  ", h.padding)
+
+	// Get bullet style
+	h.logger.Logger.mu.Lock()
+	useSpecial := h.logger.Logger.useSpecialBullets
+	customBullets := h.logger.Logger.customBullets
+	h.logger.Logger.mu.Unlock()
+
+	formatted := formatMessage(h.level, h.message, useSpecial, customBullets)
+
+	// Add fields if present
+	if len(h.fields) > 0 {
+		var parts []string
+		for k, v := range h.fields {
+			parts = append(parts, fmt.Sprintf("%s=%v", k, v))
+		}
+		formatted += colorize(dim, fmt.Sprintf(" (%s)", strings.Join(parts, ", ")))
+	}
+
+	fmt.Fprintf(h.logger.writer, "%s%s\n", indent, formatted)
+}
+
+// renderSuccess outputs the bullet as a success message
+func (h *BulletHandle) renderSuccess() {
+	indent := strings.Repeat("  ", h.padding)
+
+	h.logger.Logger.mu.Lock()
+	useSpecial := h.logger.Logger.useSpecialBullets
+	customBullets := h.logger.Logger.customBullets
+	h.logger.Logger.mu.Unlock()
+
+	// Determine bullet symbol for success
+	var bullet string
+	if custom, ok := customBullets[InfoLevel]; ok {
+		bullet = custom
+	} else if useSpecial {
+		bullet = bulletSuccess
+	} else {
+		bullet = bulletInfo
+	}
+
+	formatted := fmt.Sprintf("%s %s", colorize(green, bullet), h.message)
+
+	// Add fields if present
+	if len(h.fields) > 0 {
+		var parts []string
+		for k, v := range h.fields {
+			parts = append(parts, fmt.Sprintf("%s=%v", k, v))
+		}
+		formatted += colorize(dim, fmt.Sprintf(" (%s)", strings.Join(parts, ", ")))
+	}
+
+	fmt.Fprintf(h.logger.writer, "%s%s\n", indent, formatted)
+}
+
+// BatchUpdate allows updating multiple handles at once
+func BatchUpdate(handles []*BulletHandle, updates map[*BulletHandle]struct {
+	Level   Level
+	Message string
+}) {
+	for handle, update := range updates {
+		handle.Update(update.Level, update.Message)
+	}
+}
+
+// IncrementLineCount increments the line count (called by regular log methods)
+func (ul *UpdatableLogger) IncrementLineCount() {
+	ul.mu.Lock()
+	defer ul.mu.Unlock()
+	ul.lineCount++
+}
+
+// Override regular logging methods to track line count
+func (ul *UpdatableLogger) Info(msg string) {
+	ul.Logger.Info(msg)
+	ul.IncrementLineCount()
+}
+
+func (ul *UpdatableLogger) Debug(msg string) {
+	ul.Logger.Debug(msg)
+	ul.IncrementLineCount()
+}
+
+func (ul *UpdatableLogger) Warn(msg string) {
+	ul.Logger.Warn(msg)
+	ul.IncrementLineCount()
+}
+
+func (ul *UpdatableLogger) Error(msg string) {
+	ul.Logger.Error(msg)
+	ul.IncrementLineCount()
+}
+
+func (ul *UpdatableLogger) Success(msg string) {
+	ul.Logger.Success(msg)
+	ul.IncrementLineCount()
+}

--- a/updatable_test.go
+++ b/updatable_test.go
@@ -1,0 +1,415 @@
+package bullets
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewUpdatable(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	if logger == nil {
+		t.Fatal("NewUpdatable returned nil")
+	}
+
+	if logger.Logger == nil {
+		t.Fatal("NewUpdatable has nil Logger")
+	}
+
+	if logger.handles == nil {
+		t.Fatal("NewUpdatable has nil handles")
+	}
+}
+
+func TestBulletHandle_Update(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	// Create a handle
+	handle := logger.InfoHandle("Initial message")
+
+	// Since we're writing to a buffer (not TTY), updates won't work
+	// but we can test that the state is updated
+	handle.Update(ErrorLevel, "Updated message")
+
+	state := handle.GetState()
+	if state.Level != ErrorLevel {
+		t.Errorf("Expected level ErrorLevel, got %v", state.Level)
+	}
+
+	if state.Message != "Updated message" {
+		t.Errorf("Expected message 'Updated message', got %s", state.Message)
+	}
+}
+
+func TestBulletHandle_Success(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	handle := logger.InfoHandle("Processing...")
+	handle.Success("Completed successfully")
+
+	state := handle.GetState()
+	if state.Message != "Completed successfully" {
+		t.Errorf("Expected message 'Completed successfully', got %s", state.Message)
+	}
+}
+
+func TestBulletHandle_Error(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	handle := logger.InfoHandle("Processing...")
+	handle.Error("Failed with error")
+
+	state := handle.GetState()
+	if state.Level != ErrorLevel {
+		t.Errorf("Expected level ErrorLevel, got %v", state.Level)
+	}
+
+	if state.Message != "Failed with error" {
+		t.Errorf("Expected message 'Failed with error', got %s", state.Message)
+	}
+}
+
+func TestBulletHandle_WithFields(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	handle := logger.InfoHandle("Test message")
+	handle.WithField("key1", "value1").WithField("key2", 42)
+
+	state := handle.GetState()
+	if len(state.Fields) != 2 {
+		t.Errorf("Expected 2 fields, got %d", len(state.Fields))
+	}
+
+	if state.Fields["key1"] != "value1" {
+		t.Errorf("Expected field key1='value1', got %v", state.Fields["key1"])
+	}
+
+	if state.Fields["key2"] != 42 {
+		t.Errorf("Expected field key2=42, got %v", state.Fields["key2"])
+	}
+}
+
+func TestHandleGroup(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	// Create multiple handles
+	h1 := logger.InfoHandle("Task 1")
+	h2 := logger.InfoHandle("Task 2")
+	h3 := logger.InfoHandle("Task 3")
+
+	// Create a group
+	group := NewHandleGroup(h1, h2, h3)
+
+	if group.Size() != 3 {
+		t.Errorf("Expected group size 3, got %d", group.Size())
+	}
+
+	// Test adding a handle
+	h4 := logger.InfoHandle("Task 4")
+	group.Add(h4)
+
+	if group.Size() != 4 {
+		t.Errorf("Expected group size 4 after add, got %d", group.Size())
+	}
+
+	// Test getting a handle
+	handle := group.Get(0)
+	if handle == nil {
+		t.Error("Get(0) returned nil")
+	}
+
+	// Test updating all
+	group.UpdateAll(WarnLevel, "Warning for all")
+
+	// Verify all handles were updated
+	for i := 0; i < group.Size(); i++ {
+		h := group.Get(i)
+		state := h.GetState()
+		if state.Level != WarnLevel {
+			t.Errorf("Handle %d: expected WarnLevel, got %v", i, state.Level)
+		}
+		if state.Message != "Warning for all" {
+			t.Errorf("Handle %d: expected 'Warning for all', got %s", i, state.Message)
+		}
+	}
+
+	// Test clear
+	group.Clear()
+	if group.Size() != 0 {
+		t.Errorf("Expected group size 0 after clear, got %d", group.Size())
+	}
+}
+
+func TestHandleChain(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	// Create multiple handles
+	h1 := logger.InfoHandle("Chain 1")
+	h2 := logger.InfoHandle("Chain 2")
+	h3 := logger.InfoHandle("Chain 3")
+
+	// Create a chain and update all
+	chain := Chain(h1, h2, h3)
+	chain.Success("All successful")
+
+	// Verify all handles were updated
+	handles := []*BulletHandle{h1, h2, h3}
+	for i, h := range handles {
+		state := h.GetState()
+		if state.Message != "All successful" {
+			t.Errorf("Handle %d: expected 'All successful', got %s", i, state.Message)
+		}
+	}
+
+	// Test chaining with fields
+	chain.WithField("version", "1.0.0")
+
+	for i, h := range handles {
+		state := h.GetState()
+		if state.Fields["version"] != "1.0.0" {
+			t.Errorf("Handle %d: expected version='1.0.0', got %v", i, state.Fields["version"])
+		}
+	}
+}
+
+func TestUpdatableLogger_LineCount(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	// Log some messages
+	logger.Info("Message 1")
+	logger.Debug("Message 2")
+	logger.Warn("Message 3")
+
+	// Check line count
+	logger.mu.RLock()
+	lineCount := logger.lineCount
+	logger.mu.RUnlock()
+
+	// Debug messages might not be logged depending on level
+	// but Info and Warn should be
+	if lineCount < 2 {
+		t.Errorf("Expected line count >= 2, got %d", lineCount)
+	}
+}
+
+func TestBulletHandle_Progress(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	handle := logger.InfoHandle("Downloading...")
+
+	// Test progress updates
+	handle.Progress(25, 100)
+	state := handle.GetState()
+
+	// Check that message contains progress indicator
+	if !strings.Contains(state.Message, "[") || !strings.Contains(state.Message, "]") {
+		t.Errorf("Progress bar not found in message: %s", state.Message)
+	}
+
+	// Test 100% progress
+	handle.Progress(100, 100)
+	state = handle.GetState()
+
+	if !strings.Contains(state.Message, "100%") {
+		t.Errorf("100%% not found in message: %s", state.Message)
+	}
+}
+
+func TestHandleState(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	handle := logger.InfoHandle("Original")
+	handle.WithField("field1", "value1")
+
+	// Get state
+	state := handle.GetState()
+	if state.Level != InfoLevel {
+		t.Errorf("Expected InfoLevel, got %v", state.Level)
+	}
+	if state.Message != "Original" {
+		t.Errorf("Expected 'Original', got %s", state.Message)
+	}
+	if len(state.Fields) != 1 {
+		t.Errorf("Expected 1 field, got %d", len(state.Fields))
+	}
+
+	// Modify and set state
+	newState := HandleState{
+		Level:   ErrorLevel,
+		Message: "Modified",
+		Fields: map[string]interface{}{
+			"field2": "value2",
+		},
+	}
+
+	handle.SetState(newState)
+
+	// Verify state was set
+	currentState := handle.GetState()
+	if currentState.Level != ErrorLevel {
+		t.Errorf("Expected ErrorLevel after SetState, got %v", currentState.Level)
+	}
+	if currentState.Message != "Modified" {
+		t.Errorf("Expected 'Modified' after SetState, got %s", currentState.Message)
+	}
+	if len(currentState.Fields) != 1 || currentState.Fields["field2"] != "value2" {
+		t.Errorf("Fields not properly set: %v", currentState.Fields)
+	}
+}
+
+func TestBulletHandle_UpdateMethods(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	handle := logger.InfoHandle("Test")
+
+	// Test UpdateMessage
+	handle.UpdateMessage("New message")
+	state := handle.GetState()
+	if state.Message != "New message" {
+		t.Errorf("UpdateMessage failed: got %s", state.Message)
+	}
+
+	// Test UpdateLevel
+	handle.UpdateLevel(WarnLevel)
+	state = handle.GetState()
+	if state.Level != WarnLevel {
+		t.Errorf("UpdateLevel failed: got %v", state.Level)
+	}
+
+	// Test UpdateColor
+	handle.UpdateColor(ColorRed)
+	state = handle.GetState()
+	if state.Color != ColorRed {
+		t.Errorf("UpdateColor failed: got %s", state.Color)
+	}
+
+	// Test UpdateBullet
+	handle.UpdateBullet("▶")
+	state = handle.GetState()
+	if state.Bullet != "▶" {
+		t.Errorf("UpdateBullet failed: got %s", state.Bullet)
+	}
+}
+
+func TestHandleGroup_UpdateEach(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	// Create handles
+	h1 := logger.InfoHandle("Handle 1")
+	h2 := logger.InfoHandle("Handle 2")
+	h3 := logger.InfoHandle("Handle 3")
+
+	group := NewHandleGroup(h1, h2, h3)
+
+	// Update each with different messages
+	updates := map[int]struct {
+		Level   Level
+		Message string
+	}{
+		0: {Level: DebugLevel, Message: "Updated 1"},
+		1: {Level: WarnLevel, Message: "Updated 2"},
+		2: {Level: ErrorLevel, Message: "Updated 3"},
+	}
+
+	group.UpdateEach(updates)
+
+	// Verify updates
+	expected := []struct {
+		Level   Level
+		Message string
+	}{
+		{DebugLevel, "Updated 1"},
+		{WarnLevel, "Updated 2"},
+		{ErrorLevel, "Updated 3"},
+	}
+
+	for i, exp := range expected {
+		h := group.Get(i)
+		state := h.GetState()
+		if state.Level != exp.Level {
+			t.Errorf("Handle %d: expected level %v, got %v", i, exp.Level, state.Level)
+		}
+		if state.Message != exp.Message {
+			t.Errorf("Handle %d: expected message %s, got %s", i, exp.Message, state.Message)
+		}
+	}
+}
+
+func TestBatchUpdate(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	// Create handles
+	h1 := logger.InfoHandle("Batch 1")
+	h2 := logger.InfoHandle("Batch 2")
+	h3 := logger.InfoHandle("Batch 3")
+
+	// Prepare batch update
+	updates := map[*BulletHandle]struct {
+		Level   Level
+		Message string
+	}{
+		h1: {Level: DebugLevel, Message: "Batch Updated 1"},
+		h2: {Level: WarnLevel, Message: "Batch Updated 2"},
+		h3: {Level: ErrorLevel, Message: "Batch Updated 3"},
+	}
+
+	// Perform batch update
+	BatchUpdate([]*BulletHandle{h1, h2, h3}, updates)
+
+	// Verify updates
+	handles := []*BulletHandle{h1, h2, h3}
+	expected := []struct {
+		Level   Level
+		Message string
+	}{
+		{DebugLevel, "Batch Updated 1"},
+		{WarnLevel, "Batch Updated 2"},
+		{ErrorLevel, "Batch Updated 3"},
+	}
+
+	for i, h := range handles {
+		state := h.GetState()
+		if state.Level != expected[i].Level {
+			t.Errorf("Handle %d: expected level %v, got %v", i, expected[i].Level, state.Level)
+		}
+		if state.Message != expected[i].Message {
+			t.Errorf("Handle %d: expected message %s, got %s", i, expected[i].Message, state.Message)
+		}
+	}
+}
+
+func TestPulse(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+
+	handle := logger.InfoHandle("Original message")
+
+	// Start pulse (it runs in background)
+	handle.Pulse(500*time.Millisecond, "Alternate message")
+
+	// Wait a bit to ensure goroutine starts
+	time.Sleep(100 * time.Millisecond)
+
+	// After pulse duration, should return to original
+	time.Sleep(500 * time.Millisecond)
+
+	state := handle.GetState()
+	if state.Message != "Original message" {
+		t.Errorf("Message should return to original after pulse, got: %s", state.Message)
+	}
+}


### PR DESCRIPTION
- **feat: Add updatable bullet functionality with tests**
  

- **feat: Enhance README with updatable bullets examples and add new example for batch operations**
  

- **fix(updatable): fix concurrent updates and progress bar rendering**
  - Add writeMu mutex to serialize terminal write operations
  - Fix cursor movement to use explicit up/down instead of save/restore
  - Separate progress bar storage from message to prevent duplication
  - Add BULLETS_FORCE_TTY env var for forcing TTY mode
  - Split render methods into with/without newline variants
  - Fix WaitGroup usage in examples (replace non-existent wg.Go)
  - Add comprehensive documentation for terminal requirements
  - Handle non-TTY fallback gracefully with new line output
  