### PR TITLE
chore(ci): bump golangci-lint from v2.4.0 to v2.11.1

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -24,9 +24,9 @@ jobs:
         uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:
           repo: golangci/golangci-lint
-          tag: v2.4.0
+          tag: v2.11.1
           cache: enable
-          binaries-location: golangci-lint-2.4.0-linux-amd64
+          binaries-location: golangci-lint-2.11.1-linux-amd64
 
       - name: Run linter
         shell: /usr/bin/bash {0}


### PR DESCRIPTION
Closes #37