### PR TITLE
feat(progress): add configurable progress bar width

### DIFF
--- a/bullets.go
+++ b/bullets.go
@@ -32,6 +32,7 @@ type Logger struct {
 	useSpecialBullets bool
 	customBullets     map[Level]string
 	sanitizeInput     bool
+	progressBarWidth  int
 	writeMu           *sync.Mutex
 	coordinator       *SpinnerCoordinator
 }
@@ -52,9 +53,10 @@ func New(w io.Writer) *Logger {
 		level:             InfoLevel,
 		padding:           0,
 		fields:            make(map[string]any),
-		useSpecialBullets: false,
-		customBullets:     make(map[Level]string),
-		writeMu:           writeMu,
+		useSpecialBullets:  false,
+		customBullets:      make(map[Level]string),
+		progressBarWidth:   defaultProgressBarWidth,
+		writeMu:            writeMu,
 	}
 
 	// Initialize coordinator with shared write mutex
@@ -98,6 +100,14 @@ func (l *Logger) SetSanitizeInput(sanitize bool) {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 	l.sanitizeInput = sanitize
+}
+
+// SetProgressBarWidth sets the default width for progress bars.
+// Width is clamped to the range [5, 100]. Default is 20.
+func (l *Logger) SetProgressBarWidth(width int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.progressBarWidth = clampProgressBarWidth(width)
 }
 
 // SetBullet sets a custom bullet symbol for a specific log level.
@@ -151,6 +161,7 @@ func (l *Logger) WithField(key string, value any) *Logger {
 		fields:            make(map[string]any),
 		useSpecialBullets: l.useSpecialBullets,
 		sanitizeInput:     l.sanitizeInput,
+		progressBarWidth:  l.progressBarWidth,
 		customBullets:     make(map[Level]string),
 	}
 
@@ -174,6 +185,7 @@ func (l *Logger) WithFields(fields map[string]any) *Logger {
 		fields:            make(map[string]any),
 		useSpecialBullets: l.useSpecialBullets,
 		sanitizeInput:     l.sanitizeInput,
+		progressBarWidth:  l.progressBarWidth,
 		customBullets:     make(map[Level]string),
 	}
 

--- a/handle.go
+++ b/handle.go
@@ -125,17 +125,25 @@ func (h *BulletHandle) Pulse(ctx context.Context, duration time.Duration, altern
 	}()
 }
 
+// SetProgressBarWidth overrides the progress bar width for this handle.
+// Width is clamped to the range [5, 100]. Default is inherited from the logger.
+func (h *BulletHandle) SetProgressBarWidth(width int) *BulletHandle {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.progressBarWidth = clampProgressBarWidth(width)
+	return h
+}
+
 // Progress updates the bullet to show progress.
 func (h *BulletHandle) Progress(current, total int) *BulletHandle {
 	const percentMultiplier = 100
 	percentage := (current * percentMultiplier) / total
-	progressBar := renderProgressBar(percentage)
 
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
 	// Store progress bar separately, keep message intact
-	h.progressBar = progressBar
+	h.progressBar = renderProgressBar(percentage, h.progressBarWidth)
 
 	if h.lineNum != -1 && h.logger.isTTY {
 		h.redraw()
@@ -143,12 +151,25 @@ func (h *BulletHandle) Progress(current, total int) *BulletHandle {
 	return h
 }
 
+const (
+	defaultProgressBarWidth = 20
+	minProgressBarWidth     = 5
+	maxProgressBarWidth     = 100
+)
+
+func clampProgressBarWidth(width int) int {
+	if width < minProgressBarWidth {
+		return minProgressBarWidth
+	}
+	if width > maxProgressBarWidth {
+		return maxProgressBarWidth
+	}
+	return width
+}
+
 // renderProgressBar creates a simple ASCII progress bar.
-func renderProgressBar(percentage int) string {
-	const (
-		barWidth         = 20
-		percentMultiplier = 100
-	)
+func renderProgressBar(percentage, barWidth int) string {
+	const percentMultiplier = 100
 	filled := (percentage * barWidth) / percentMultiplier
 
 	var bar strings.Builder

--- a/handle_test.go
+++ b/handle_test.go
@@ -85,7 +85,7 @@ func TestRenderProgressBar(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := renderProgressBar(tt.percentage)
+		result := renderProgressBar(tt.percentage, defaultProgressBarWidth)
 
 		// Check for percentage in result
 		expectedPercentage := fmt.Sprintf("%d%%", tt.percentage)
@@ -97,6 +97,67 @@ func TestRenderProgressBar(t *testing.T) {
 		if !strings.HasPrefix(result, "[") {
 			t.Errorf("Progress bar for %d%% doesn't start with '[': %s", tt.percentage, result)
 		}
+	}
+}
+
+func TestRenderProgressBar_CustomWidth(t *testing.T) {
+	// Width 10 at 50%: 5 filled chars
+	result := renderProgressBar(50, 10)
+	if !strings.Contains(result, "50%") {
+		t.Errorf("Expected 50%% in result: %s", result)
+	}
+	equalsCount := strings.Count(result, "=")
+	if equalsCount != 5 { // filled = (50*10)/100 = 5, positions 0-4 get '='
+		t.Errorf("Expected 5 '=' chars for 50%% at width 10, got %d in: %s", equalsCount, result)
+	}
+
+	// Width 40 at 100%: 40 filled chars
+	result = renderProgressBar(100, 40)
+	if !strings.Contains(result, "100%") {
+		t.Errorf("Expected 100%% in result: %s", result)
+	}
+	equalsCount = strings.Count(result, "=")
+	if equalsCount != 40 {
+		t.Errorf("Expected 40 '=' chars for 100%% at width 40, got %d", equalsCount)
+	}
+}
+
+func TestClampProgressBarWidth(t *testing.T) {
+	tests := []struct {
+		input    int
+		expected int
+	}{
+		{0, minProgressBarWidth},
+		{3, minProgressBarWidth},
+		{5, 5},
+		{20, 20},
+		{100, 100},
+		{150, maxProgressBarWidth},
+		{-10, minProgressBarWidth},
+	}
+	for _, tt := range tests {
+		result := clampProgressBarWidth(tt.input)
+		if result != tt.expected {
+			t.Errorf("clampProgressBarWidth(%d) = %d, want %d", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestBulletHandle_SetProgressBarWidth(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+	handle := logger.InfoHandle("Downloading...")
+
+	handle.SetProgressBarWidth(10)
+	handle.Progress(50, 100)
+
+	if !strings.Contains(handle.progressBar, "50%") {
+		t.Errorf("Expected 50%% in progress bar: %s", handle.progressBar)
+	}
+	// Bar with width 10 should be shorter than default width 20
+	defaultBar := renderProgressBar(50, defaultProgressBarWidth)
+	if len(handle.progressBar) >= len(defaultBar) {
+		t.Errorf("Custom width 10 bar should be shorter than default: got %q vs %q", handle.progressBar, defaultBar)
 	}
 }
 

--- a/updatable.go
+++ b/updatable.go
@@ -32,9 +32,10 @@ type BulletHandle struct {
 	progressBar    string  // Store progress bar separately
 	color          string
 	bullet         string
-	padding        int
-	fields         map[string]any
-	mu             sync.Mutex
+	padding          int
+	progressBarWidth int
+	fields           map[string]any
+	mu               sync.Mutex
 }
 
 // NewUpdatable creates a new updatable logger.
@@ -161,25 +162,27 @@ func (ul *UpdatableLogger) logHandle(level Level, msg string) *BulletHandle {
 	// If not a TTY, return a handle that prints updates as new lines
 	if !ul.isTTY {
 		return &BulletHandle{
-			logger:          ul,
-			lineNum:         -1,
-			level:           level,
-			message:         msg,
-			originalMessage: msg,
-			padding:         ul.padding,
-			fields:          make(map[string]any),
+			logger:           ul,
+			lineNum:          -1,
+			level:            level,
+			message:          msg,
+			originalMessage:  msg,
+			padding:          ul.padding,
+			progressBarWidth: ul.progressBarWidth,
+			fields:           make(map[string]any),
 		}
 	}
 
 	// Create and register handle
 	handle := &BulletHandle{
-		logger:          ul,
-		lineNum:         ul.lineCount,
-		level:           level,
-		message:         msg,
-		originalMessage: msg,
-		padding:         ul.padding,
-		fields:          make(map[string]any),
+		logger:           ul,
+		lineNum:          ul.lineCount,
+		level:            level,
+		message:          msg,
+		originalMessage:  msg,
+		padding:          ul.padding,
+		progressBarWidth: ul.progressBarWidth,
+		fields:           make(map[string]any),
 	}
 
 	// Copy fields from logger (already have the lock)

--- a/updatable_test.go
+++ b/updatable_test.go
@@ -239,6 +239,25 @@ func TestBulletHandle_Progress(t *testing.T) {
 	}
 }
 
+func TestBulletHandle_ProgressBarWidthFromLogger(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := NewUpdatable(buf)
+	logger.SetProgressBarWidth(10)
+
+	handle := logger.InfoHandle("Task...")
+	handle.Progress(50, 100)
+
+	if !strings.Contains(handle.progressBar, "50%") {
+		t.Errorf("Expected 50%% in progress bar: %s", handle.progressBar)
+	}
+	// Width 10: bar portion should be "[=====>    ]" (12 chars including brackets)
+	// Total should be shorter than default width 20
+	defaultBar := renderProgressBar(50, defaultProgressBarWidth)
+	if len(handle.progressBar) >= len(defaultBar) {
+		t.Errorf("Logger width 10 bar should be shorter than default: got %q vs %q", handle.progressBar, defaultBar)
+	}
+}
+
 func TestHandleState(t *testing.T) {
 	buf := &bytes.Buffer{}
 	logger := NewUpdatable(buf)


### PR DESCRIPTION
- Add progressBarWidth field to Logger and BulletHandle
- Add SetProgressBarWidth() on Logger and BulletHandle
- Add clampProgressBarWidth() with range [5, 100]
- Update renderProgressBar() to accept width parameter
- Propagate width through WithField/WithFields and handle creation
- Add tests for custom width, clamping, and inheritance

Refs #41