### PR TITLE
chore(ci): use go-version-file instead of hardcoded Go versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>= 1.25'
+          go-version-file: 'go.mod'
   
       - name: coverage
         id: coverage

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: stable
+          go-version-file: 'go.mod'
       - name: Install task
         uses: jaxxstorm/action-install-gh-release@v2.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: '>= 1.25'
+          go-version-file: 'go.mod'
       - uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v6
         with:
-          go-version: '>= 1.25'
+          go-version-file: 'go.mod'
 
       - name: Cache Go modules
         uses: actions/cache@v5


### PR DESCRIPTION
- Replace hardcoded go-version with go-version-file: 'go.mod'
  in coverage, linter, release, and tests workflows

Refs #43