### PR TITLE
fix(logger): serialize writes from concurrent derived loggers

### DIFF
--- a/bullets.go
+++ b/bullets.go
@@ -163,6 +163,8 @@ func (l *Logger) WithField(key string, value any) *Logger {
 		sanitizeInput:     l.sanitizeInput,
 		progressBarWidth:  l.progressBarWidth,
 		customBullets:     make(map[Level]string),
+		writeMu:           l.writeMu,
+		coordinator:       l.coordinator,
 	}
 
 	maps.Copy(newLogger.fields, l.fields)
@@ -187,6 +189,8 @@ func (l *Logger) WithFields(fields map[string]any) *Logger {
 		sanitizeInput:     l.sanitizeInput,
 		progressBarWidth:  l.progressBarWidth,
 		customBullets:     make(map[Level]string),
+		writeMu:           l.writeMu,
+		coordinator:       l.coordinator,
 	}
 
 	maps.Copy(newLogger.fields, l.fields)
@@ -281,7 +285,9 @@ func (l *Logger) Success(msg string) {
 
 	formatted := fmt.Sprintf("%s %s", colorize(green, bullet), msg)
 
+	l.writeMu.Lock()
 	fmt.Fprintf(l.writer, "%s%s\n", indent, formatted)
+	l.writeMu.Unlock()
 }
 
 // Successf logs a formatted success message.
@@ -295,7 +301,9 @@ func (l *Logger) Ln() {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
+	l.writeMu.Lock()
 	fmt.Fprintln(l.writer)
+	l.writeMu.Unlock()
 }
 
 // Step logs a step message with timing information.
@@ -456,7 +464,9 @@ func (l *Logger) log(level Level, msg string) {
 	}
 
 	// Write to output
+	l.writeMu.Lock()
 	fmt.Fprintf(l.writer, "%s%s\n", indent, formatted)
+	l.writeMu.Unlock()
 }
 
 // registerSpinner adds a spinner to the active spinners list and returns its line number.

--- a/bullets_test.go
+++ b/bullets_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -282,5 +283,36 @@ func TestWithFieldPreservesSettings(t *testing.T) {
 
 	if newLogger.padding != logger.padding {
 		t.Error("WithField should preserve padding")
+	}
+}
+
+// TestConcurrentDerivedLoggers exercises the race that BenchmarkWorstCase_ConcurrentStress
+// surfaced: multiple goroutines deriving loggers via WithField and writing to a shared
+// underlying writer must serialize their writes. Without writeMu propagation in WithField
+// (and a writeMu-guarded write in log()), this test trips -race.
+func TestConcurrentDerivedLoggers(t *testing.T) {
+	var buf bytes.Buffer
+	logger := New(&buf)
+
+	const goroutines = 32
+	const perGoroutine = 50
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(id int) {
+			defer wg.Done()
+			derived := logger.WithField("goroutine", id)
+			for j := 0; j < perGoroutine; j++ {
+				derived.Info("concurrent")
+				derived.Success("ok")
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	lines := strings.Count(buf.String(), "\n")
+	if want := goroutines * perGoroutine * 2; lines != want {
+		t.Errorf("expected %d output lines, got %d", want, lines)
 	}
 }


### PR DESCRIPTION
WithField/WithFields constructed a derived *Logger that did not
inherit writeMu or coordinator from the parent, and log/Success/Ln
wrote to l.writer while only holding the per-logger state mutex.
Concurrent goroutines using logger.WithField(...).Info(...) on a
shared writer therefore raced on bytes.Buffer.Write — reproduced
by BenchmarkWorstCase_ConcurrentStress under -race.

- WithField/WithFields propagate writeMu and coordinator
- log/Success/Ln lock writeMu around the actual writer call
- add TestConcurrentDerivedLoggers regression test

Closes #45