### PR TITLE
fix(logger): eliminate concurrency races causing unexpected output

### DIFF
--- a/debug.go
+++ b/debug.go
@@ -3,6 +3,7 @@ package bullets
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"time"
 )
@@ -32,6 +33,8 @@ var (
 	debugMu sync.RWMutex
 	// debugTestMode disables Once caching for testing (always re-read env var).
 	debugTestMode bool
+	// debugWriteMu serializes writes to stderr so concurrent debug lines don't interleave.
+	debugWriteMu sync.Mutex
 )
 
 // resetDebugLevel resets the debug level initialization state.
@@ -137,7 +140,10 @@ func debugLog(component, format string, args ...any) {
 		elapsed.Milliseconds()%1000) //nolint:mnd // Milliseconds per second
 
 	message := fmt.Sprintf(format, args...)
-	fmt.Fprintf(os.Stderr, "[%s] [%s] %s\n", timestamp, component, message)
+	line := fmt.Sprintf("[%s] [%s] %s\n", timestamp, component, message)
+	debugWriteMu.Lock()
+	_, _ = os.Stderr.WriteString(line)
+	debugWriteMu.Unlock()
 }
 
 // debugLogVerbose writes a verbose debug message, only if verbose debugging is enabled.
@@ -231,10 +237,6 @@ func (c *SpinnerCoordinator) renderDebugMap() {
 		return
 	}
 
-	fmt.Fprintf(os.Stderr, "\n┌─────────────────────────────────────────────────────────────┐\n")
-	fmt.Fprintf(os.Stderr, "│ Spinner Position Map (active: %d)                            \n", state.activeSpinners)
-	fmt.Fprintf(os.Stderr, "├─────────────────────────────────────────────────────────────┤\n")
-
 	// Find the highest line number
 	maxLine := -1
 	for lineNum := range state.lineAllocations {
@@ -243,18 +245,25 @@ func (c *SpinnerCoordinator) renderDebugMap() {
 		}
 	}
 
-	// Show all lines from 0 to max
+	var buf strings.Builder
+	fmt.Fprintf(&buf, "\n┌─────────────────────────────────────────────────────────────┐\n")
+	fmt.Fprintf(&buf, "│ Spinner Position Map (active: %d)                            \n", state.activeSpinners)
+	fmt.Fprintf(&buf, "├─────────────────────────────────────────────────────────────┤\n")
+
 	for i := 0; i <= maxLine; i++ {
 		if desc, ok := state.lineAllocations[i]; ok {
-			fmt.Fprintf(os.Stderr, "│ Line %d: %-52s│\n", i, desc)
+			fmt.Fprintf(&buf, "│ Line %d: %-52s│\n", i, desc)
 		} else {
-			fmt.Fprintf(os.Stderr, "│ Line %d: <empty>                                             │\n", i)
+			fmt.Fprintf(&buf, "│ Line %d: <empty>                                             │\n", i)
 		}
 	}
 
-	// Show cursor position (always at bottom in our model)
-	fmt.Fprintf(os.Stderr, "│ Cursor: Line %d                                              │\n", maxLine+1)
-	fmt.Fprintf(os.Stderr, "└─────────────────────────────────────────────────────────────┘\n\n")
+	fmt.Fprintf(&buf, "│ Cursor: Line %d                                              │\n", maxLine+1)
+	fmt.Fprintf(&buf, "└─────────────────────────────────────────────────────────────┘\n\n")
+
+	debugWriteMu.Lock()
+	_, _ = os.Stderr.WriteString(buf.String())
+	debugWriteMu.Unlock()
 }
 
 // validateDebugMode runs validation checks when debug mode is enabled.

--- a/handle.go
+++ b/handle.go
@@ -95,7 +95,9 @@ func (h *BulletHandle) Pulse(ctx context.Context, duration time.Duration, altern
 		return
 	}
 
+	h.mu.Lock()
 	originalMsg := h.message
+	h.mu.Unlock()
 
 	go func() {
 		const pulseInterval = 500 * time.Millisecond

--- a/race_regression_test.go
+++ b/race_regression_test.go
@@ -1,0 +1,149 @@
+package bullets
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestUpdatableConcurrentWritesAndHandle exercises B1/B2/B3: concurrent
+// Info/Success calls on UpdatableLogger plus a goroutine repeatedly updating
+// a BulletHandle. Before the fix, writes could race on lineCount and
+// UpdatableLogger.Success bypassed writeMu — the race detector flagged both.
+// In non-TTY mode handle.Update falls back to a plain log line, but the
+// internal mutex acquisition pattern still exercises ul.mu vs. the embedded
+// Logger.writeMu plumbing — the value of this test is the -race signal.
+func TestUpdatableConcurrentWritesAndHandle(t *testing.T) {
+	var buf bytes.Buffer
+	ul := NewUpdatable(&buf)
+
+	handle := ul.InfoHandle("seed")
+
+	const writers = 8
+	const perWriter = 200
+
+	var wg sync.WaitGroup
+	wg.Add(writers + 1)
+
+	for i := 0; i < writers; i++ {
+		go func() {
+			defer wg.Done()
+			for j := 0; j < perWriter; j++ {
+				ul.Info("info")
+				ul.Success("done")
+			}
+		}()
+	}
+
+	go func() {
+		defer wg.Done()
+		for j := 0; j < perWriter*writers; j++ {
+			handle.Update(InfoLevel, "tick")
+		}
+	}()
+
+	wg.Wait()
+
+	// Output line accounting in non-TTY mode:
+	//   - InfoHandle("seed") writes 1 line via ul.log (logHandle does not
+	//     bump lineCount in non-TTY).
+	//   - writers*perWriter*2 lines from Info+Success.
+	//   - writers*perWriter lines from handle.Update's non-TTY fallback,
+	//     which also goes through the base Logger.log (no lineCount bump).
+	wantLines := 1 + writers*perWriter*2 + writers*perWriter
+	if got := strings.Count(buf.String(), "\n"); got != wantLines {
+		t.Errorf("expected %d output lines, got %d", wantLines, got)
+	}
+
+	// lineCount only counts what UpdatableLogger.Info/Success bumped:
+	// writers*perWriter*2.
+	ul.mu.RLock()
+	gotCount := ul.lineCount
+	ul.mu.RUnlock()
+	if want := writers * perWriter * 2; gotCount != want {
+		t.Errorf("expected lineCount %d, got %d", want, gotCount)
+	}
+}
+
+// TestSpinnerCtxRaceWithSuccess exercises B4: race a context timeout against a
+// manual Success() call. With the completion gate, exactly one of the two
+// paths renders, and Success() never returns before the spinner is fully torn
+// down. Before the fix, both paths queued an updateComplete and the visible
+// outcome was non-deterministic; this also tripped the race detector
+// occasionally on the spinner's stop/done bookkeeping.
+func TestSpinnerCtxRaceWithSuccess(t *testing.T) {
+	t.Setenv("BULLETS_FORCE_TTY", "0") // exercise the non-TTY path; deterministic output
+
+	var ctxWon, manualWon atomic.Int64
+
+	const iters = 200
+	for i := 0; i < iters; i++ {
+		var buf bytes.Buffer
+		logger := New(&buf)
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+		spinner := logger.Spinner(ctx, "work")
+
+		// Race: ctx will fire ~1ms; Success fires after a tiny variable delay.
+		var done sync.WaitGroup
+		done.Add(1)
+		go func() {
+			defer done.Done()
+			// Vary the delay to interleave both orderings.
+			time.Sleep(time.Duration(i%3) * 500 * time.Microsecond)
+			spinner.Success("ok")
+		}()
+		done.Wait()
+		cancel()
+
+		out := buf.String()
+		switch {
+		case strings.Contains(out, "ok"):
+			manualWon.Add(1)
+		case strings.Contains(out, "context") || strings.Contains(out, "deadline"):
+			ctxWon.Add(1)
+		default:
+			t.Fatalf("iteration %d produced no completion line: %q", i, out)
+		}
+
+		// Crucially: each iteration must produce exactly ONE completion line.
+		// The first line is the spinner's static non-TTY frame ("work"),
+		// the second is the completion. No more.
+		nLines := strings.Count(out, "\n")
+		if nLines != 2 {
+			t.Fatalf("iteration %d expected 2 lines (frame + completion), got %d: %q",
+				i, nLines, out)
+		}
+	}
+
+	// Sanity check: across 200 randomized iterations we should see both
+	// outcomes — otherwise the test is degenerate (always taking one branch).
+	if ctxWon.Load() == 0 || manualWon.Load() == 0 {
+		t.Logf("ctx wins: %d, manual wins: %d (expected at least 1 of each)",
+			ctxWon.Load(), manualWon.Load())
+	}
+}
+
+// TestPulseNoRace exercises B5: Pulse used to read h.message without h.mu,
+// racing concurrent UpdateMessage calls. With the fix the read is locked.
+func TestPulseNoRace(t *testing.T) {
+	t.Setenv("BULLETS_FORCE_TTY", "1")
+
+	var buf bytes.Buffer
+	ul := NewUpdatable(&buf)
+	handle := ul.InfoHandle("seed")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	handle.Pulse(ctx, 10*time.Millisecond, "alt")
+
+	// Hammer UpdateMessage while Pulse is running — race detector must stay quiet.
+	for i := 0; i < 1000; i++ {
+		handle.UpdateMessage("update")
+	}
+}

--- a/spinner.go
+++ b/spinner.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"golang.org/x/term"
@@ -43,6 +44,7 @@ type Spinner struct {
 	doneCh     chan bool
 	mu         sync.Mutex
 	stopped    bool
+	completed  atomic.Bool    // Gate so only the first completion path (manual vs ctx-cancel) renders.
 	lineNumber int            // Line position (0 = bottom, 1 = second from bottom, etc.)
 	isTTY      bool           // Whether output is a TTY
 	ctxDone    <-chan struct{} // Context Done channel for cancellation support
@@ -286,7 +288,19 @@ func (s *Spinner) stopAnimation() {
 
 // completeSpinner is a helper method that handles spinner completion logic.
 // It stops the animation and renders the completion message with the specified color and bullet.
+//
+// Gated by s.completed: if context cancellation has already begun rendering its
+// own completion, this call becomes a no-op (waits for the spinner to finish so
+// the caller doesn't return before the spinner is gone).
 func (s *Spinner) completeSpinner(msg, color, bullet string) {
+	if !s.completed.CompareAndSwap(false, true) {
+		// A concurrent completion path (typically context cancellation) has
+		// already begun. Wait for animate() to exit so the spinner is fully
+		// torn down before this caller returns.
+		<-s.doneCh
+		return
+	}
+
 	// Stop animation but don't unregister yet
 	s.stopAnimation()
 
@@ -351,7 +365,15 @@ func (s *Spinner) animate() {
 // handleContextCancellation renders the cancellation message when a spinner's context
 // is cancelled. This method is called from animate() and must NOT call stopAnimation()
 // to avoid deadlocking on doneCh.
+//
+// Gated by s.completed: if a manual Success/Error/Replace has already begun
+// rendering its own completion, skip the ctx-cancellation render.
 func (s *Spinner) handleContextCancellation() {
+	if !s.completed.CompareAndSwap(false, true) {
+		// Manual completion already won the gate. Nothing more to render here.
+		return
+	}
+
 	msg := s.ctxErr().Error()
 
 	s.logger.mu.Lock()

--- a/updatable.go
+++ b/updatable.go
@@ -12,11 +12,15 @@ import (
 )
 
 // UpdatableLogger wraps a regular Logger and provides updatable bullet functionality.
+//
+// Terminal writes are serialized via the embedded Logger.writeMu (*sync.Mutex),
+// which is also shared with the SpinnerCoordinator's cursor service. Routing
+// every write through that single mutex prevents handle redraws from
+// interleaving with regular log lines or spinner frames.
 type UpdatableLogger struct {
 	*Logger
 
 	mu        sync.RWMutex
-	writeMu   sync.Mutex  // Mutex for terminal write operations
 	handles   []*BulletHandle
 	lineCount int  // Track total lines written
 	isTTY     bool // Whether output is a terminal
@@ -79,34 +83,34 @@ func (ul *UpdatableLogger) ErrorHandle(msg string) *BulletHandle {
 
 // Info logs an info message and increments line count.
 func (ul *UpdatableLogger) Info(msg string) {
-	ul.log(InfoLevel, msg)
 	ul.mu.Lock()
+	defer ul.mu.Unlock()
+	ul.log(InfoLevel, msg)
 	ul.lineCount++
-	ul.mu.Unlock()
 }
 
 // Debug logs a debug message and increments line count.
 func (ul *UpdatableLogger) Debug(msg string) {
-	ul.log(DebugLevel, msg)
 	ul.mu.Lock()
+	defer ul.mu.Unlock()
+	ul.log(DebugLevel, msg)
 	ul.lineCount++
-	ul.mu.Unlock()
 }
 
 // Warn logs a warning message and increments line count.
 func (ul *UpdatableLogger) Warn(msg string) {
-	ul.log(WarnLevel, msg)
 	ul.mu.Lock()
+	defer ul.mu.Unlock()
+	ul.log(WarnLevel, msg)
 	ul.lineCount++
-	ul.mu.Unlock()
 }
 
 // Error logs an error message and increments line count.
 func (ul *UpdatableLogger) Error(msg string) {
-	ul.log(ErrorLevel, msg)
 	ul.mu.Lock()
+	defer ul.mu.Unlock()
+	ul.log(ErrorLevel, msg)
 	ul.lineCount++
-	ul.mu.Unlock()
 }
 
 // Success logs a success message and increments line count.
@@ -119,7 +123,8 @@ func (ul *UpdatableLogger) Success(msg string) {
 	}
 
 	if InfoLevel < ul.level {
-		ul.lineCount++
+		// Don't bump lineCount when the line is suppressed — terminal cursor
+		// hasn't moved and any tracked handle would point to the wrong row.
 		return
 	}
 
@@ -136,7 +141,10 @@ func (ul *UpdatableLogger) Success(msg string) {
 	}
 
 	formatted := fmt.Sprintf("%s %s", colorize(green, bullet), msg)
+
+	ul.writeMu.Lock()
 	fmt.Fprintf(ul.writer, "%s%s\n", indent, formatted)
+	ul.writeMu.Unlock()
 	ul.lineCount++
 }
 
@@ -317,14 +325,18 @@ func (h *BulletHandle) redrawSuccess() {
 }
 
 // redrawWithRenderer performs the redraw operation with a custom renderer.
+//
+// Holds ul.mu.RLock for the whole sequence (read lineCount → take writeMu →
+// move/clear/write/move-back → release writeMu). RLock blocks writers from
+// incrementing lineCount mid-redraw, so the cursor offset stays consistent
+// with the terminal state.
 func (h *BulletHandle) redrawWithRenderer(renderer func()) {
 	h.logger.mu.RLock()
-	currentLine := h.logger.lineCount
-	h.logger.mu.RUnlock()
+	defer h.logger.mu.RUnlock()
 
+	currentLine := h.logger.lineCount
 	linesToMoveUp := currentLine - h.lineNum
 
-	// Lock for terminal write operations
 	h.logger.writeMu.Lock()
 	defer h.logger.writeMu.Unlock()
 
@@ -355,11 +367,13 @@ func (h *BulletHandle) redrawWithRenderer(renderer func()) {
 func (h *BulletHandle) renderInPlace() {
 	indent := strings.Repeat("  ", h.padding)
 
-	// Get bullet style
-	h.logger.mu.Lock()
+	// Bullet style fields live on the embedded Logger; use Logger.mu, not the
+	// shadowing UpdatableLogger.mu (which is held RLocked by redrawWithRenderer
+	// above us — taking it here as a write lock would deadlock).
+	h.logger.Logger.mu.Lock()
 	useSpecial := h.logger.useSpecialBullets
 	customBullets := h.logger.customBullets
-	h.logger.mu.Unlock()
+	h.logger.Logger.mu.Unlock()
 
 	formatted := formatMessage(h.level, h.message, useSpecial, customBullets)
 
@@ -384,10 +398,10 @@ func (h *BulletHandle) renderInPlace() {
 func (h *BulletHandle) renderSuccessInPlace() {
 	indent := strings.Repeat("  ", h.padding)
 
-	h.logger.mu.Lock()
+	h.logger.Logger.mu.Lock()
 	useSpecial := h.logger.useSpecialBullets
 	customBullets := h.logger.customBullets
-	h.logger.mu.Unlock()
+	h.logger.Logger.mu.Unlock()
 
 	// Determine bullet symbol for success
 	var bullet string


### PR DESCRIPTION
- B1: hold ul.mu around UpdatableLogger.{Info,Debug,Warn,Error,Success}
  log+lineCount; hold ul.mu.RLock through handle redraw's writeMu section
  so lineCount stays consistent with the terminal cursor.
- B2: wrap UpdatableLogger.Success Fprintf in writeMu; stop bumping
  lineCount when the message is level-suppressed.
- B3: delete the shadowing UpdatableLogger.writeMu and route all writes
  through the embedded Logger.writeMu (shared with the spinner
  coordinator). Fix renderInPlace/renderSuccessInPlace to use the
  embedded Logger.mu, the correct mutex for the fields they read.
- B4: gate spinner completion on s.completed atomic.Bool — ctx-cancel
  and manual Success/Error/Replace race deterministically; the loser
  waits on doneCh so callers don't return before teardown finishes.
- B5: read h.message under h.mu in BulletHandle.Pulse.
- B8: serialize debugLog stderr writes via debugWriteMu and pre-format
  the renderDebugMap output to one Write call.

Adds race_regression_test.go with targeted tests for B1/B2/B3, B4 and
B5. Full suite passes under go test -race -count=5 ./...

B6 (goroutine leak — coordinator channels never closed) and B7
(completion send can block on full updateCh under stress) documented
but deferred — both need API decisions.

Closes #48