### PR TITLE
ci: pin toolchain with mise instead of setup actions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,12 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # setup go environment
-      - name: Set up Go
-        uses: actions/setup-go@v7
+      # Toolchain (Go, task, golangci-lint, ...) is pinned in mise.toml
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: 'go.mod'
-  
+          install: true
+          cache: true
       - name: coverage
         id: coverage
         run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -11,23 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-go@v7
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: 'go.mod'
-      - name: Install task
-        uses: jaxxstorm/action-install-gh-release@v3.0.0
-        with:
-          repo: go-task/task
-          cache: enable
-          # tag: 
-      - name: Install golangci-lint
-        uses: jaxxstorm/action-install-gh-release@v3.0.0
-        with:
-          repo: golangci/golangci-lint
-          tag: v2.11.1
-          cache: enable
-          binaries-location: golangci-lint-2.11.1-linux-amd64
-
+          install: true
+          cache: true
       - name: Run linter
         shell: /usr/bin/bash {0}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,13 +15,11 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v7
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: 'go.mod'
-      - uses: goreleaser/goreleaser-action@v7
-        with:
-          distribution: goreleaser
-          version: latest
-          args: release --clean
+          install: true
+          cache: true
+      - name: Create release
+        run: goreleaser release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,11 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Go
-        uses: actions/setup-go@v7
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: 'go.mod'
-
+          install: true
+          cache: true
       - name: Cache Go modules
         uses: actions/cache@v6
         with:

--- a/.github/workflows/vulnerability-scan.yml
+++ b/.github/workflows/vulnerability-scan.yml
@@ -23,12 +23,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@v7
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: 'go.mod'
-
+          install: true
+          cache: true
       - name: Run govulncheck
-        uses: golang/govulncheck-action@v1
-        with:
-          go-package: ./...
+        run: task vulncheck

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,11 @@ tasks:
       - go generate ./...
       - golangci-lint run
 
+  vulncheck:
+    desc: "Scan dependencies for known vulnerabilities"
+    cmds:
+      - govulncheck ./...
+
   tests:
     desc: "Run tests"
     cmds:

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,6 @@
+[tools]
+go = "1.25.12"
+task = "3.40.1"
+golangci-lint = "2.11.1"
+goreleaser = "2.16.0"
+"go:golang.org/x/vuln/cmd/govulncheck" = "1.6.0"


### PR DESCRIPTION
- add mise.toml pinning go, task, golangci-lint, goreleaser and govulncheck versions
- replace actions/setup-go and jaxxstorm/action-install-gh-release with jdx/mise-action in coverage, linter, release, tests and vulnerability-scan workflows
- run goreleaser and govulncheck directly instead of via their dedicated actions
- add vulncheck task to Taskfile.yml